### PR TITLE
fix 'European Union', 'Europe' wrong result

### DIFF
--- a/test/is-abbreviation.js
+++ b/test/is-abbreviation.js
@@ -18,5 +18,5 @@ test('not an abbreviation', t => {
   t.same(isAbbreviation('Cheesy Potatoes', 'cheetos'), false);
   t.same(isAbbreviation('Thankgod It\'s Friday', 'TGIF'), false);
   t.same(isAbbreviation('Call me maybe', 'calbe'), false);
-  t.same(isAbbreviation('European Union', 'Europe'), true);
+  t.same(isAbbreviation('European Union', 'Europe'), false);
 });


### PR DESCRIPTION
fix wrong testcase for is-abbreviation
European Union, Europe should be false
